### PR TITLE
Fixed include directories on Windows + WSL

### DIFF
--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -121,20 +121,22 @@ function m.generate(prj)
 
 		-- include dirs
 
+		_p('if(CMAKE_BUILD_TYPE STREQUAL %s) # Include dirs', cmake.cfgname(cfg))
 		if #cfg.externalincludedirs > 0 then
-			_p('target_include_directories("%s" SYSTEM PRIVATE', prj.name)
+			_p(1, 'target_include_directories("%s" SYSTEM PRIVATE', prj.name)
 			for _, includedir in ipairs(cfg.externalincludedirs) do
-				_x(1, '$<$<CONFIG:%s>:%s>', cmake.cfgname(cfg), includedir)
+				_x(2, '%s', includedir)
 			end
-			_p(')')
+			_p(1, ')')
 		end
 		if #cfg.includedirs > 0 then
-			_p('target_include_directories("%s" PRIVATE', prj.name)
+			_p(1, 'target_include_directories("%s" PRIVATE', prj.name)
 			for _, includedir in ipairs(cfg.includedirs) do
-				_x(1, '$<$<CONFIG:%s>:%s>', cmake.cfgname(cfg), includedir)
+				_x(2, '%s', includedir)
 			end
-			_p(')')
+			_p(1, ')')
 		end
+		_p('endif()')
 
 		if #cfg.forceincludes > 0 then
 			_p('if (MSVC)')
@@ -154,13 +156,18 @@ function m.generate(prj)
 		end
 
 		-- lib dirs
+
+		-- Don't really know if this has the same issue as Include Directories on Windows
+		--  though it doesn't hurt to have this if statement.
+		_p('if(CMAKE_BUILD_TYPE STREQUAL %s) # Lib dirs', cmake.cfgname(cfg))
 		if #cfg.libdirs > 0 then
-			_p('target_link_directories("%s" PRIVATE', prj.name)
+			_p(1, 'target_link_directories("%s" PRIVATE', prj.name)
 			for _, libdir in ipairs(cfg.libdirs) do
-				_p(1, '$<$<CONFIG:%s>:%s>', cmake.cfgname(cfg), libdir)
+				_p(2, '%s', libdir)
 			end
-			_p(')')
+			_p(1, ')')
 		end
+		_p('endif()')
 
 		-- libs
 		local uselinkgroups = isclangorgcc and cfg.linkgroups == p.ON

--- a/cmake_project.lua
+++ b/cmake_project.lua
@@ -125,14 +125,14 @@ function m.generate(prj)
 		if #cfg.externalincludedirs > 0 then
 			_p(1, 'target_include_directories("%s" SYSTEM PRIVATE', prj.name)
 			for _, includedir in ipairs(cfg.externalincludedirs) do
-				_x(2, '%s', includedir)
+				_x(2, '%s', path.getrelative(prj.workspace.location, includedir))
 			end
 			_p(1, ')')
 		end
 		if #cfg.includedirs > 0 then
 			_p(1, 'target_include_directories("%s" PRIVATE', prj.name)
 			for _, includedir in ipairs(cfg.includedirs) do
-				_x(2, '%s', includedir)
+				_x(2, '%s', path.getrelative(prj.workspace.location, includedir))
 			end
 			_p(1, ')')
 		end
@@ -157,13 +157,11 @@ function m.generate(prj)
 
 		-- lib dirs
 
-		-- Don't really know if this has the same issue as Include Directories on Windows
-		--  though it doesn't hurt to have this if statement.
 		_p('if(CMAKE_BUILD_TYPE STREQUAL %s) # Lib dirs', cmake.cfgname(cfg))
 		if #cfg.libdirs > 0 then
 			_p(1, 'target_link_directories("%s" PRIVATE', prj.name)
 			for _, libdir in ipairs(cfg.libdirs) do
-				_p(2, '%s', libdir)
+				_p(2, '%s', path.getrelative(prj.workspace.location, libdir))
 			end
 			_p(1, ')')
 		end


### PR DESCRIPTION
The colon after the drive letters on Windows doesn't really work well with CMake's generator-expressions.

Before Changes:
![Before CMakeLists.txt](https://user-images.githubusercontent.com/46133335/222929193-f608512c-be9a-4d3d-a40f-f7d53103d1dd.png)
![Before CMake Output](https://user-images.githubusercontent.com/46133335/222929217-64e10e61-f66a-4f51-a2c0-5331d8d4fec8.png)

After Changes:
![After CMakeLists.txt](https://user-images.githubusercontent.com/46133335/222929244-153433ee-8c9e-489f-853e-66da530a1d12.png)

I'm using CMake from Visual Studio, the version that's shipped with VS is CMake 3.25.1-msvc1.
Maybe this issue is fixed on newer versions.
